### PR TITLE
Added a new plugin for query and result mapping

### DIFF
--- a/ApisearchPluginsBundle.php
+++ b/ApisearchPluginsBundle.php
@@ -20,6 +20,7 @@ use Apisearch\Plugin\Elastica\ElasticaPluginBundle;
 use Apisearch\Plugin\ELK\ELKPluginBundle;
 use Apisearch\Plugin\MostRelevantWords\MostRelevantWordsPluginBundle;
 use Apisearch\Plugin\NewRelic\NewRelicPluginBundle;
+use Apisearch\Plugin\QueryMapper\QueryMapperPluginBundle;
 use Apisearch\Plugin\RabbitMQ\RabbitMQPluginBundle;
 use Apisearch\Plugin\RedisMetadataFields\RedisMetadataFieldsPluginBundle;
 use Apisearch\Plugin\RedisQueue\RedisQueuePluginBundle;
@@ -87,6 +88,7 @@ class ApisearchPluginsBundle extends BaseBundle
             'static_tokens' => StaticTokensPluginBundle::class,
             'rabbitmq' => RabbitMQPluginBundle::class,
             'security' => SecurityPluginBundle::class,
+            'query_mapper' => QueryMapperPluginBundle::class,
         ];
 
         $combined = array_combine(

--- a/Controller/QueryController.php
+++ b/Controller/QueryController.php
@@ -44,7 +44,7 @@ class QueryController extends ControllerWithBus
         $requestQuery = $request->query;
         $queryModel = RequestContentExtractor::extractQuery($request);
 
-        $responseAsArray = $this
+        $result = $this
             ->commandBus
             ->handle(new Query(
                 RepositoryReference::create(
@@ -60,11 +60,17 @@ class QueryController extends ControllerWithBus
                         Http::INDEX_FIELD,
                     ]);
                 }, ARRAY_FILTER_USE_KEY)
-            ))
-            ->toArray();
+            ));
+
+        /*
+         * To allow result manipulation during the response returning, and in
+         * order to increase performance, we will save the Result instance as a
+         * query attribute
+         */
+        $requestQuery->set('result', $result);
 
         return new JsonResponse(
-            $responseAsArray,
+            $result->toArray(),
             200,
             [
                 'Access-Control-Allow-Origin' => '*',

--- a/Plugin/QueryMapper/DependencyInjection/QueryMapperPluginConfiguration.php
+++ b/Plugin/QueryMapper/DependencyInjection/QueryMapperPluginConfiguration.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\DependencyInjection;
+
+use Mmoreram\BaseBundle\DependencyInjection\BaseConfiguration;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+/**
+ * Class QueryMapperPluginConfiguration.
+ */
+class QueryMapperPluginConfiguration extends BaseConfiguration
+{
+    /**
+     * Configure the root node.
+     *
+     * @param ArrayNodeDefinition $rootNode Root node
+     */
+    protected function setupTree(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('query_mappers')
+                    ->scalarPrototype()
+                    ->end()
+                ->end()
+                ->arrayNode('result_mappers')
+                    ->scalarPrototype()
+                    ->end()
+                ->end();
+    }
+}

--- a/Plugin/QueryMapper/DependencyInjection/QueryMapperPluginExtension.php
+++ b/Plugin/QueryMapper/DependencyInjection/QueryMapperPluginExtension.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\DependencyInjection;
+
+use Mmoreram\BaseBundle\DependencyInjection\BaseExtension;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * Class QueryMapperPluginExtension.
+ */
+class QueryMapperPluginExtension extends BaseExtension
+{
+    /**
+     * Returns the recommended alias to use in XML.
+     *
+     * This alias is also the mandatory prefix to use when using YAML.
+     *
+     * @return string The alias
+     */
+    public function getAlias()
+    {
+        return 'apisearch_plugin_query_mapper';
+    }
+
+    /**
+     * Get the Config file location.
+     *
+     * @return string
+     */
+    protected function getConfigFilesLocation(): string
+    {
+        return __DIR__.'/../Resources/config';
+    }
+
+    /**
+     * Config files to load.
+     *
+     * Each array position can be a simple file name if must be loaded always,
+     * or an array, with the filename in the first position, and a boolean in
+     * the second one.
+     *
+     * As a parameter, this method receives all loaded configuration, to allow
+     * setting this boolean value from a configuration value.
+     *
+     * return array(
+     *      'file1.yml',
+     *      'file2.yml',
+     *      ['file3.yml', $config['my_boolean'],
+     *      ...
+     * );
+     *
+     * @param array $config Config definitions
+     *
+     * @return array Config files
+     */
+    protected function getConfigFiles(array $config): array
+    {
+        return [
+            'domain',
+            'listeners',
+        ];
+    }
+
+    /**
+     * Load Parametrization definition.
+     *
+     * return array(
+     *      'parameter1' => $config['parameter1'],
+     *      'parameter2' => $config['parameter2'],
+     *      ...
+     * );
+     *
+     * @param array $config Bundles config values
+     *
+     * @return array
+     */
+    protected function getParametrizationValues(array $config): array
+    {
+        return [
+            'apisearch_plugin.query_mapper.query_mappers' => $config['query_mappers'],
+            'apisearch_plugin.query_mapper.result_mappers' => $config['result_mappers'],
+        ];
+    }
+
+    /**
+     * Return a new Configuration instance.
+     *
+     * If object returned by this method is an instance of
+     * ConfigurationInterface, extension will use the Configuration to read all
+     * bundle config definitions.
+     *
+     * Also will call getParametrizationValues method to load some config values
+     * to internal parameters.
+     *
+     * @return ConfigurationInterface|null
+     */
+    protected function getConfigurationInstance(): ? ConfigurationInterface
+    {
+        return new QueryMapperPluginConfiguration($this->getAlias());
+    }
+}

--- a/Plugin/QueryMapper/Domain/QueryMapper.php
+++ b/Plugin/QueryMapper/Domain/QueryMapper.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Domain;
+
+use Apisearch\Query\Query;
+use Apisearch\Repository\RepositoryReference;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class QueryMapper.
+ */
+interface QueryMapper
+{
+    /**
+     * Get mapping token.
+     *
+     * @return string
+     */
+    public function getMappingToken(): string;
+
+    /**
+     * Get mapped credentials.
+     *
+     * @return RepositoryReference
+     */
+    public function getRepositoryReference(): RepositoryReference;
+
+    /**
+     * Get token.
+     *
+     * @return string
+     */
+    public function getToken(): string;
+
+    /**
+     * Build query.
+     *
+     * @param Request $request
+     *
+     * @return Query
+     */
+    public function buildQueryByRequest(Request $request): Query;
+}

--- a/Plugin/QueryMapper/Domain/QueryMapperLoader.php
+++ b/Plugin/QueryMapper/Domain/QueryMapperLoader.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Domain;
+
+use Apisearch\Http\Http;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class QueryMapperLoader.
+ */
+class QueryMapperLoader
+{
+    /**
+     * @var QueryMappers
+     *
+     * Query mappers
+     */
+    private $queryMappers;
+
+    /**
+     * Load query mappers.
+     *
+     * @param array $namespaces
+     */
+    public function __construct(array $namespaces)
+    {
+        $this->queryMappers = new QueryMappers();
+        foreach ($namespaces as $namespace) {
+            $this
+                ->queryMappers
+                ->addQueryMapper(new $namespace());
+        }
+    }
+
+    /**
+     * Having a Request query parameters, build a Query and fulfill credentials
+     * if needed.
+     *
+     * @param Request $request
+     */
+    public function fulfillRequestWithQueryAndCredentials(Request $request)
+    {
+        $requestQuery = $request->query;
+        $token = $requestQuery->get(Http::TOKEN_FIELD);
+        if (empty($token)) {
+            return;
+        }
+
+        $queryMapper = $this
+            ->queryMappers
+            ->findQueryMapperByToken($token);
+
+        if (!$queryMapper instanceof QueryMapper) {
+            return;
+        }
+
+        $repositoryReference = $queryMapper->getRepositoryReference();
+        $requestQuery->set(HttP::APP_ID_FIELD, $repositoryReference->getAppUUID()->composeUUID());
+        $requestQuery->set(HttP::INDEX_FIELD, $repositoryReference->getIndexUUID()->composeUUID());
+        $requestQuery->set(HttP::TOKEN_FIELD, $queryMapper->getToken());
+        $requestQuery->set(HttP::QUERY_FIELD, json_encode(
+            $queryMapper->buildQueryByRequest($request)->toArray()
+        ));
+    }
+}

--- a/Plugin/QueryMapper/Domain/QueryMappers.php
+++ b/Plugin/QueryMapper/Domain/QueryMappers.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Domain;
+
+/**
+ * Class QueryMappers.
+ */
+class QueryMappers
+{
+    /**
+     * @var QueryMapper[]
+     *
+     * Query mappers
+     */
+    private $queryMappers = [];
+
+    /**
+     * Add query mapper.
+     *
+     * @param QueryMapper
+     */
+    public function addQueryMapper(QueryMapper $queryMapper)
+    {
+        $this->queryMappers[] = $queryMapper;
+    }
+
+    /**
+     * Find query mapper by token.
+     *
+     * @param string $token
+     *
+     * @return QueryMapper|null
+     */
+    public function findQueryMapperByToken(string $token): ? QueryMapper
+    {
+        foreach ($this->queryMappers as $queryMapper) {
+            if ($queryMapper->getMappingToken() === $token) {
+                return $queryMapper;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Plugin/QueryMapper/Domain/ResultMapper.php
+++ b/Plugin/QueryMapper/Domain/ResultMapper.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Domain;
+
+use Apisearch\Result\Result;
+
+/**
+ * Class ResultMapper.
+ */
+interface ResultMapper
+{
+    /**
+     * Get token.
+     *
+     * @return string
+     */
+    public function getToken(): string;
+
+    /**
+     * Build array.
+     *
+     * @param Result $result
+     *
+     * @return array
+     */
+    public function buildArrayFromResult(Result $result): array;
+}

--- a/Plugin/QueryMapper/Domain/ResultMapperLoader.php
+++ b/Plugin/QueryMapper/Domain/ResultMapperLoader.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Domain;
+
+use Apisearch\Model\TokenUUID;
+use Apisearch\Result\Result;
+
+/**
+ * Class ResultMapperLoader.
+ */
+class ResultMapperLoader
+{
+    /**
+     * @var ResultMappers
+     *
+     * Result mappers
+     */
+    private $resultMappers;
+
+    /**
+     * Load query mappers.
+     *
+     * @param array $namespaces
+     */
+    public function __construct(array $namespaces)
+    {
+        $this->resultMappers = new ResultMappers();
+        foreach ($namespaces as $namespace) {
+            $this
+                ->resultMappers
+                ->addResultMapper(new $namespace());
+        }
+    }
+
+    /**
+     * Having a Result object, if needed, transform it into a regular array.
+     *
+     * @param TokenUUID $tokenUUID
+     * @param Result    $result
+     *
+     * @return array|null
+     */
+    public function getArrayFromResult(
+        TokenUUID $tokenUUID,
+        Result $result
+    ): ? array {
+        $resultMapper = $this
+            ->resultMappers
+            ->findResultMapperByToken($tokenUUID->composeUUID());
+
+        if (!$resultMapper instanceof ResultMapper) {
+            return null;
+        }
+
+        return $resultMapper->buildArrayFromResult($result);
+    }
+}

--- a/Plugin/QueryMapper/Domain/ResultMappers.php
+++ b/Plugin/QueryMapper/Domain/ResultMappers.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Domain;
+
+/**
+ * Class ResultMappers.
+ */
+class ResultMappers
+{
+    /**
+     * @var ResultMapper[]
+     *
+     * Result mappers
+     */
+    private $resultMappers = [];
+
+    /**
+     * Add result mapper.
+     *
+     * @param ResultMapper
+     */
+    public function addResultMapper(ResultMapper $resultMapper)
+    {
+        $this->resultMappers[] = $resultMapper;
+    }
+
+    /**
+     * Find result mapper by token.
+     *
+     * @param string $token
+     *
+     * @return ResultMapper|null
+     */
+    public function findResultMapperByToken(string $token): ? ResultMapper
+    {
+        foreach ($this->resultMappers as $resultMapper) {
+            if ($resultMapper->getToken() === $token) {
+                return $resultMapper;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Plugin/QueryMapper/Listener/CheckMappedQuery.php
+++ b/Plugin/QueryMapper/Listener/CheckMappedQuery.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Listener;
+
+use Apisearch\Plugin\QueryMapper\Domain\QueryMapperLoader;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * Class CheckMappedQuery.
+ */
+class CheckMappedQuery
+{
+    /**
+     * @var QueryMapperLoader
+     *
+     * Query mapper loader
+     */
+    private $queryMapperLoader;
+
+    /**
+     * CheckMappingQueries constructor.
+     *
+     * @param QueryMapperLoader $queryMapperLoader
+     */
+    public function __construct(QueryMapperLoader $queryMapperLoader)
+    {
+        $this->queryMapperLoader = $queryMapperLoader;
+    }
+
+    /**
+     * On kernel request.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $route = $request->get('_route');
+
+        if ('search_server_api_query' !== $route) {
+            return;
+        }
+
+        $this
+            ->queryMapperLoader
+            ->fulfillRequestWithQueryAndCredentials(
+                $event->getRequest()
+            );
+    }
+}

--- a/Plugin/QueryMapper/Listener/CheckMappedResult.php
+++ b/Plugin/QueryMapper/Listener/CheckMappedResult.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Listener;
+
+use Apisearch\Http\Http;
+use Apisearch\Model\Token;
+use Apisearch\Plugin\QueryMapper\Domain\ResultMapperLoader;
+use Apisearch\Result\Result;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * Class CheckMappedResult.
+ */
+class CheckMappedResult
+{
+    /**
+     * @var ResultMapperLoader
+     *
+     * Result mapper loader
+     */
+    private $resultMapperLoader;
+
+    /**
+     * CheckMappingQueries constructor.
+     *
+     * @param ResultMapperLoader $resultMapperLoader
+     */
+    public function __construct(ResultMapperLoader $resultMapperLoader)
+    {
+        $this->resultMapperLoader = $resultMapperLoader;
+    }
+
+    /**
+     * On kernel response.
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $route = $request->get('_route');
+
+        if (
+            'search_server_api_query' !== $route ||
+            !$request->query->get(Http::TOKEN_FIELD) instanceof Token ||
+            !$request->get('result') instanceof Result
+        ) {
+            return;
+        }
+
+        $response = $this
+            ->resultMapperLoader
+            ->getArrayFromResult(
+                $request->query->get(Http::TOKEN_FIELD)->getTokenUUID(),
+                $request->get('result')
+            );
+
+        if (is_array($response)) {
+            $event->setResponse(new JsonResponse(
+                $response,
+                200,
+                [
+                    'Access-Control-Allow-Origin' => '*',
+                ]
+            ));
+        }
+    }
+}

--- a/Plugin/QueryMapper/QueryMapperPluginBundle.php
+++ b/Plugin/QueryMapper/QueryMapperPluginBundle.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper;
+
+use Apisearch\Plugin\QueryMapper\DependencyInjection\QueryMapperPluginExtension;
+use Apisearch\Server\ApisearchServerBundle;
+use Apisearch\Server\Domain\Plugin\Plugin;
+use Apisearch\Server\Domain\Plugin\QueuePlugin;
+use Mmoreram\BaseBundle\BaseBundle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Class QueryMapperPluginBundle.
+ */
+class QueryMapperPluginBundle extends BaseBundle implements Plugin, QueuePlugin
+{
+    /**
+     * Returns the bundle's container extension.
+     *
+     * @return ExtensionInterface|null The container extension
+     */
+    public function getContainerExtension()
+    {
+        return new QueryMapperPluginExtension();
+    }
+
+    /**
+     * Return all bundle dependencies.
+     *
+     * Values can be a simple bundle namespace or its instance
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return array
+     */
+    public static function getBundleDependencies(KernelInterface $kernel): array
+    {
+        return [
+            ApisearchServerBundle::class,
+        ];
+    }
+
+    /**
+     * Get plugin name.
+     *
+     * @return string
+     */
+    public function getPluginName(): string
+    {
+        return 'query_mapper';
+    }
+}

--- a/Plugin/QueryMapper/Resources/config/domain.yml
+++ b/Plugin/QueryMapper/Resources/config/domain.yml
@@ -1,0 +1,11 @@
+services:
+
+    apisearch_plugin.query_mapper.query_mapper_loader:
+        class: Apisearch\Plugin\QueryMapper\Domain\QueryMapperLoader
+        arguments:
+            - "%apisearch_plugin.query_mapper.query_mappers%"
+
+    apisearch_plugin.query_mapper.result_mapper_loader:
+        class: Apisearch\Plugin\QueryMapper\Domain\ResultMapperLoader
+        arguments:
+            - "%apisearch_plugin.query_mapper.result_mappers%"

--- a/Plugin/QueryMapper/Resources/config/listeners.yml
+++ b/Plugin/QueryMapper/Resources/config/listeners.yml
@@ -1,0 +1,15 @@
+services:
+
+    apisearch_plugin.query_mapper.check_mapped_query:
+        class: Apisearch\Plugin\QueryMapper\Listener\CheckMappedQuery
+        arguments:
+            - '@apisearch_plugin.query_mapper.query_mapper_loader'
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 24 }
+
+    apisearch_plugin.query_mapper.check_mapped_result:
+        class: Apisearch\Plugin\QueryMapper\Listener\CheckMappedResult
+        arguments:
+            - '@apisearch_plugin.query_mapper.result_mapper_loader'
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: -24 }

--- a/Plugin/QueryMapper/Tests/Functional/Mappers/SimpleQueryMapper.php
+++ b/Plugin/QueryMapper/Tests/Functional/Mappers/SimpleQueryMapper.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Tests\Functional\Mappers;
+
+use Apisearch\Model\AppUUID;
+use Apisearch\Model\IndexUUID;
+use Apisearch\Model\ItemUUID;
+use Apisearch\Plugin\QueryMapper\Domain\QueryMapper;
+use Apisearch\Query\Query;
+use Apisearch\Repository\RepositoryReference;
+use Apisearch\Server\Tests\Functional\ApisearchServerBundleFunctionalTest;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class SimpleQueryMapper.
+ */
+class SimpleQueryMapper implements QueryMapper
+{
+    /**
+     * Get mapping token.
+     *
+     * @return string
+     */
+    public function getMappingToken(): string
+    {
+        return 'query-mapped-simple';
+    }
+
+    /**
+     * Get mapped credentials.
+     *
+     * @return RepositoryReference
+     */
+    public function getRepositoryReference(): RepositoryReference
+    {
+        return RepositoryReference::create(
+            AppUUID::createById(ApisearchServerBundleFunctionalTest::$appId),
+            IndexUUID::createById(ApisearchServerBundleFunctionalTest::$index)
+        );
+    }
+
+    /**
+     * Get token.
+     *
+     * @return string
+     */
+    public function getToken(): string
+    {
+        return ApisearchServerBundleFunctionalTest::$godToken;
+    }
+
+    /**
+     * Build query.
+     *
+     * @param Request $request
+     *
+     * @return Query
+     */
+    public function buildQueryByRequest(Request $request): Query
+    {
+        return Query::createByUUIDs([
+            ItemUUID::createByComposedUUID('4~bike'),
+            ItemUUID::createByComposedUUID('2~product'),
+        ]);
+    }
+}

--- a/Plugin/QueryMapper/Tests/Functional/Mappers/SimpleResultMapper.php
+++ b/Plugin/QueryMapper/Tests/Functional/Mappers/SimpleResultMapper.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Tests\Functional\Mappers;
+
+use Apisearch\Model\Item;
+use Apisearch\Plugin\QueryMapper\Domain\ResultMapper;
+use Apisearch\Result\Result;
+use Apisearch\Server\Tests\Functional\ApisearchServerBundleFunctionalTest;
+
+/**
+ * Class SimpleResultMapper.
+ */
+class SimpleResultMapper implements ResultMapper
+{
+    /**
+     * Get token.
+     *
+     * @return string
+     */
+    public function getToken(): string
+    {
+        return ApisearchServerBundleFunctionalTest::$readonlyToken;
+    }
+
+    /**
+     * Build array.
+     *
+     * @param Result $result
+     *
+     * @return array
+     */
+    public function buildArrayFromResult(Result $result): array
+    {
+        return [
+            'item_nb' => count($result->getItems()),
+            'item_ids' => array_map(function (Item $item) {
+                return $item->composeUUID();
+            }, $result->getItems()),
+        ];
+    }
+}

--- a/Plugin/QueryMapper/Tests/Functional/QueryMappedTest.php
+++ b/Plugin/QueryMapper/Tests/Functional/QueryMappedTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Tests\Functional;
+
+use Apisearch\Model\Item;
+use Apisearch\Model\ItemUUID;
+use Apisearch\Query\Query;
+use Apisearch\Result\Result;
+
+/**
+ * Class QueryMappedTest.
+ */
+class QueryMappedTest extends QueryMapperFunctionalTest
+{
+    /**
+     * Basic usage.
+     */
+    public function testWithMappedQuery()
+    {
+        $client = static::createClient();
+        $client->request(
+            'get',
+            '/v1?token=query-mapped-simple'
+        );
+
+        $resultAsJson = $client->getResponse()->getContent();
+        $result = Result::createFromArray(json_decode($resultAsJson, true));
+        $this->assertEquals(2, $result->getTotalHits());
+        $this->assertEquals('2~product', $result->getItems()[0]->composeUUID());
+        $this->assertEquals('4~bike', $result->getItems()[1]->composeUUID());
+    }
+
+    /**
+     * Test without mapped query.
+     */
+    public function testWithoutMappedQuery()
+    {
+        $client = static::createClient();
+        $client->request(
+            'get',
+            '/v1?token=non-existing'
+        );
+
+        $resultAsJson = $client->getResponse()->getContent();
+        $resultAsArray = json_decode($resultAsJson, true);
+        $this->assertEquals(401, $resultAsArray['code']);
+    }
+
+    /**
+     * Test another endpoint.
+     */
+    public function testAnotherEndpoint()
+    {
+        $client = static::createClient();
+        $client->request(
+            'post',
+            sprintf('/v1/items?app_id=%s&index=%s&token=%s',
+                static::$appId,
+                static::$index,
+                static::$godToken
+            ),
+            [], [], [
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            json_encode([
+                'items' => [
+                    Item::create(
+                        ItemUUID::createByComposedUUID('10~lele')
+                    )->toArray(),
+                ],
+            ])
+        );
+
+        $this->assertCount(6, $this
+            ->query(Query::createMatchAll())
+            ->getItems()
+        );
+    }
+}

--- a/Plugin/QueryMapper/Tests/Functional/QueryMapperFunctionalTest.php
+++ b/Plugin/QueryMapper/Tests/Functional/QueryMapperFunctionalTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Tests\Functional;
+
+use Apisearch\Plugin\QueryMapper\QueryMapperPluginBundle;
+use Apisearch\Plugin\QueryMapper\Tests\Functional\Mappers\SimpleQueryMapper;
+use Apisearch\Plugin\QueryMapper\Tests\Functional\Mappers\SimpleResultMapper;
+use Apisearch\Server\Tests\Functional\ServiceFunctionalTest;
+
+/**
+ * Class QueryMapperFunctionalTest.
+ */
+abstract class QueryMapperFunctionalTest extends ServiceFunctionalTest
+{
+    /**
+     * Decorate bundles.
+     *
+     * @param array $bundles
+     *
+     * @return array
+     */
+    protected static function decorateBundles(array $bundles): array
+    {
+        $bundles = parent::decorateBundles($bundles);
+        $bundles[] = QueryMapperPluginBundle::class;
+
+        return $bundles;
+    }
+
+    /**
+     * Decorate configuration.
+     *
+     * @param array $configuration
+     *
+     * @return array
+     */
+    protected static function decorateConfiguration(array $configuration): array
+    {
+        $configuration = parent::decorateConfiguration($configuration);
+        $configuration['apisearch_plugin_query_mapper']['query_mappers'] = [
+            SimpleQueryMapper::class,
+        ];
+        $configuration['apisearch_plugin_query_mapper']['result_mappers'] = [
+            SimpleResultMapper::class,
+        ];
+
+        return $configuration;
+    }
+}

--- a/Plugin/QueryMapper/Tests/Functional/ResultMappedTest.php
+++ b/Plugin/QueryMapper/Tests/Functional/ResultMappedTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\QueryMapper\Tests\Functional;
+
+/**
+ * Class ResultMappedTest.
+ */
+class ResultMappedTest extends QueryMapperFunctionalTest
+{
+    /**
+     * Basic usage.
+     */
+    public function testBasicUsage()
+    {
+        $client = static::createClient();
+        $client->request(
+            'get',
+            sprintf('/v1?app_id=%s&index=%s&token=%s',
+                static::$appId,
+                static::$index,
+                static::$readonlyToken
+            )
+        );
+
+        $resultAsJson = $client->getResponse()->getContent();
+        $resultAsArray = json_decode($resultAsJson, true);
+        $this->assertEquals([
+            'item_nb' => 5,
+            'item_ids' => [
+                '1~product',
+                '2~product',
+                '3~book',
+                '4~bike',
+                '5~gum',
+            ],
+        ], $resultAsArray);
+    }
+}

--- a/Tests/Functional/ApisearchServerBundleFunctionalTest.php
+++ b/Tests/Functional/ApisearchServerBundleFunctionalTest.php
@@ -30,6 +30,7 @@ use Apisearch\Result\Result;
 use Apisearch\Server\ApisearchPluginsBundle;
 use Apisearch\Server\ApisearchServerBundle;
 use Apisearch\Server\Exception\ErrorException;
+use Apisearch\User\Interaction;
 use Mmoreram\BaseBundle\BaseBundle;
 use Mmoreram\BaseBundle\Kernel\BaseKernel;
 use Mmoreram\BaseBundle\Tests\BaseFunctionalTest;
@@ -701,18 +702,14 @@ abstract class ApisearchServerBundleFunctionalTest extends BaseFunctionalTest
     /**
      * Add interaction.
      *
-     * @param string $userId
-     * @param string $itemUUIDComposed
-     * @param int    $weight
-     * @param string $appId
-     * @param Token  $token
+     * @param Interaction $interaction
+     * @param string      $appId
+     * @param Token       $token
      */
     abstract public function addInteraction(
-        string $userId,
-        string $itemUUIDComposed,
-        int $weight,
-        string $appId,
-        Token $token
+        Interaction $interaction,
+        string $appId = null,
+        Token $token = null
     );
 
     /**

--- a/Tests/Functional/CurlFunctionalTest.php
+++ b/Tests/Functional/CurlFunctionalTest.php
@@ -26,9 +26,9 @@ use Apisearch\Model\Item;
 use Apisearch\Model\ItemUUID;
 use Apisearch\Model\Token;
 use Apisearch\Model\TokenUUID;
-use Apisearch\Model\User;
 use Apisearch\Query\Query as QueryModel;
 use Apisearch\Result\Result;
+use Apisearch\User\Interaction;
 
 /**
  * Class CurlFunctionalTest.
@@ -381,7 +381,7 @@ abstract class CurlFunctionalTest extends ApisearchServerBundleFunctionalTest
 
         return array_map(function (array $tokenAsArray) {
             return Token::createFromArray($tokenAsArray);
-        }, $result['body']);
+        }, $response['body']);
     }
 
     /**
@@ -405,29 +405,21 @@ abstract class CurlFunctionalTest extends ApisearchServerBundleFunctionalTest
     /**
      * Add interaction.
      *
-     * @param string $userId
-     * @param string $itemUUIDComposed
-     * @param int    $weight
-     * @param string $appId
-     * @param Token  $token
+     * @param Interaction $interaction
+     * @param string      $appId
+     * @param Token       $token
      */
     public function addInteraction(
-        string $userId,
-        string $itemUUIDComposed,
-        int $weight,
-        string $appId,
-        Token $token
+        Interaction $interaction,
+        string $appId = null,
+        Token $token = null
     ) {
         self::$lastResponse = self::makeCurl(
             'v1-interactions',
             $appId,
             null,
             $token,
-            [
-                'user' => User::createFromArray(['id' => $userId]),
-                'item_uuid' => ItemUUID::createByComposedUUID($itemUUIDComposed),
-                'weight' => $weight,
-            ]
+            ['interaction' => $interaction->toArray()]
         );
     }
 

--- a/Tests/Functional/HttpFunctionalTest.php
+++ b/Tests/Functional/HttpFunctionalTest.php
@@ -300,25 +300,17 @@ abstract class HttpFunctionalTest extends ApisearchServerBundleFunctionalTest
     /**
      * Add interaction.
      *
-     * @param string $userId
-     * @param string $itemUUIDComposed
-     * @param int    $weight
-     * @param string $appId
-     * @param Token  $token
+     * @param Interaction $interaction
+     * @param string      $appId
+     * @param Token       $token
      */
     public function addInteraction(
-        string $userId,
-        string $itemUUIDComposed,
-        int $weight,
-        string $appId,
-        Token $token
+        Interaction $interaction,
+        string $appId = null,
+        Token $token = null
     ) {
         self::configureUserRepository($appId, $token)
-            ->addInteraction(new Interaction(
-                new User($userId),
-                ItemUUID::createByComposedUUID($itemUUIDComposed),
-                $weight
-            ));
+            ->addInteraction($interaction);
     }
 
     /**

--- a/Tests/Functional/ServiceFunctionalTest.php
+++ b/Tests/Functional/ServiceFunctionalTest.php
@@ -24,7 +24,6 @@ use Apisearch\Model\Item;
 use Apisearch\Model\ItemUUID;
 use Apisearch\Model\Token;
 use Apisearch\Model\TokenUUID;
-use Apisearch\Model\User;
 use Apisearch\Query\Query as QueryModel;
 use Apisearch\Repository\RepositoryReference;
 use Apisearch\Result\Result;
@@ -506,18 +505,14 @@ abstract class ServiceFunctionalTest extends ApisearchServerBundleFunctionalTest
     /**
      * Add interaction.
      *
-     * @param string $userId
-     * @param string $itemUUIDComposed
-     * @param int    $weight
-     * @param string $appId
-     * @param Token  $token
+     * @param Interaction $interaction
+     * @param string      $appId
+     * @param Token       $token
      */
     public function addInteraction(
-        string $userId,
-        string $itemUUIDComposed,
-        int $weight,
-        string $appId,
-        Token $token
+        Interaction $interaction,
+        string $appId = null,
+        Token $token = null
     ) {
         $appUUID = AppUUID::createById($appId ?? self::$appId);
 
@@ -529,11 +524,7 @@ abstract class ServiceFunctionalTest extends ApisearchServerBundleFunctionalTest
                         TokenUUID::createById(self::getParameterStatic('apisearch_server.god_token')),
                         $appUUID
                     ),
-                new Interaction(
-                    new User($userId),
-                    ItemUUID::createByComposedUUID($itemUUIDComposed),
-                    $weight
-                )
+                $interaction
             ));
 
         static::waitAfterWriteCommand();


### PR DESCRIPTION
- You can map a token to an app_id, index, an internal token  and an specific token. You
  only have to create a new QueryMapper instance for that
- You can map a token to a ResultMapper, changing the format of the result for external
  clients, for example
- Recommendable to put these new classes inside the Custom folder