### PR TITLE
When printing tokens from console, we must reload first

### DIFF
--- a/Domain/ImperativeEvent/LoadTokens.php
+++ b/Domain/ImperativeEvent/LoadTokens.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Server\Domain\ImperativeEvent;
+
+use Apisearch\Model\AppUUID;
+
+/**
+ * Class LoadTokens.
+ */
+final class LoadTokens
+{
+    /**
+     * @var AppUUID
+     */
+    private $appUUID;
+
+    /**
+     * LoadTokens constructor.
+     *
+     * @param AppUUID $appUUID
+     */
+    public function __construct(AppUUID $appUUID)
+    {
+        $this->appUUID = $appUUID;
+    }
+
+    /**
+     * @return AppUUID
+     */
+    public function getAppUUID(): AppUUID
+    {
+        return $this->appUUID;
+    }
+}

--- a/Domain/Repository/AppRepository/TokenRepository.php
+++ b/Domain/Repository/AppRepository/TokenRepository.php
@@ -22,6 +22,7 @@ use Apisearch\Repository\RepositoryReference;
 use Apisearch\Server\Domain\Event\TokensWereDeleted;
 use Apisearch\Server\Domain\Event\TokenWasDeleted;
 use Apisearch\Server\Domain\Event\TokenWasPut;
+use Apisearch\Server\Domain\ImperativeEvent\LoadTokens;
 use Apisearch\Server\Domain\Token\TokenLocator;
 use Apisearch\Server\Domain\Token\TokenProvider;
 use Drift\HttpKernel\AsyncKernelEvents;
@@ -171,6 +172,9 @@ abstract class TokenRepository implements TokenLocator, TokenProvider, EventSubs
                 ['forceLoadAllTokens', 0],
             ],
             AsyncKernelEvents::PRELOAD => [
+                ['forceLoadAllTokens', 0],
+            ],
+            LoadTokens::class => [
                 ['forceLoadAllTokens', 0],
             ],
         ];

--- a/Domain/Repository/Repository/Repository.php
+++ b/Domain/Repository/Repository/Repository.php
@@ -26,7 +26,7 @@ use React\Promise\PromiseInterface;
 /**
  * Class Repository.
  */
-class Repository
+final class Repository
 {
     /**
      * @var ItemsRepository

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -39,9 +39,8 @@ services:
     #
     # Repositories
     #
-    Apisearch\Server\Domain\Repository\:
-        resource: '../../Domain/Repository/'
-
+    Apisearch\Server\Domain\Repository\Repository\Repository:
+    Apisearch\Server\Domain\Repository\AppRepository\Repository:
     Apisearch\Server\Domain\Repository\AppRepository\TokenRepository:
         class: Apisearch\Server\Domain\Repository\AppRepository\InMemoryTokenRepository
         public: true

--- a/Tests/Functional/Domain/Token/TokenTest.php
+++ b/Tests/Functional/Domain/Token/TokenTest.php
@@ -331,8 +331,25 @@ abstract class TokenTest extends HttpFunctionalTest
         );
 
         $this->assertCount(4, $this->getTokensFromKernel($clusterKernel));
-        $clusterKernel->shutdown();
-        unset($clusterKernel);
+
+        /**
+         * Existing service.
+         */
+        $output = static::runCommand([
+            'apisearch-server:print-token',
+            'app-id' => $appUUID->composeUUID(),
+        ]);
+        $this->assertContains('multiservice-token', $output);
+
+        /**
+         * New service.
+         */
+        $process = static::runAsyncCommand([
+            'apisearch-server:print-token',
+            $appUUID->composeUUID(),
+        ]);
+        sleep(1);
+        $this->assertContains('multiservice-token', $process->getOutput());
     }
 
     /**
@@ -344,7 +361,7 @@ abstract class TokenTest extends HttpFunctionalTest
      *
      * @return Token[]
      */
-    protected static function getTokensFromKernel(
+    private static function getTokensFromKernel(
         KernelInterface $kernel,
         string $appId = null,
         Token $token = null

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
     "symfony/browser-kit": "^4.3",
     "clue/block-react": "*",
     "clue/reactphp-sqlite": "*",
-    "phpunit/phpunit": "7.5.18"
+    "phpunit/phpunit": "7.5.18",
+    "symfony/process": "^5.0.0"
   },
 
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0028c0200736696001a083d5b86646a",
+    "content-hash": "6e371641daf6fdd51b2890903b908c2e",
     "packages": [
         {
             "name": "alecrabbit/php-cli-snake",
@@ -7287,6 +7287,55 @@
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
             "time": "2020-02-29T10:07:09+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "fd4a86dd7e36437f2fc080d8c42c7415d828a0a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/fd4a86dd7e36437f2fc080d8c42c7415d828a0a8",
+                "reference": "fd4a86dd7e36437f2fc080d8c42c7415d828a0a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-02-08T17:00:58+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/docker-compose/docker-compose-infra.yml
+++ b/docker-compose/docker-compose-infra.yml
@@ -25,14 +25,14 @@ services:
         ports:
             - "6379:6379"
 
-    postgresql:
-        image: postgres:alpine
+    mysql:
+        image: mysql:5
         networks: [apisearch]
         ports:
-            - "5432:5432"
+            - "3306:3306"
         environment:
-            POSTGRES_USER: root
-            POSTGRES_PASSWORD: root
-            POSTGRES_DB: apisearch
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: apisearch
+
 networks:
     apisearch:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,9 @@
         <env name="APISEARCH_TOKENS_UPDATE_EXCHANGE" value="tokens_update" force="true" />
 
         <env name="ELASTICSEARCH_HOST" value="apisearch.elasticsearch.latest" force="true" />
+        <env name="AMQP_HOST" value="apisearch.rabbitmq" force="true" />
+        <env name="REDIS_HOST" value="apisearch.redis" force="true" />
+        <env name="LOGSTASH_REDIS_HOST" value="apisearch.redis" force="true" />
 
         <env name="DBAL_DRIVER" value="mysql" force="true" />
         <env name="DBAL_HOST" value="apisearch.mysql" force="true" />
@@ -27,11 +30,5 @@
         <env name="DBAL_PASSWORD" value="root" force="true" />
         <env name="DBAL_DBNAME" value="apisearch" force="true" />
         <env name="DBAL_TOKENS_TABLE" value="tokens" force="true" />
-
-        <env name="AMQP_HOST" value="apisearch.rabbitmq" force="true" />
-
-        <env name="REDIS_HOST" value="apisearch.redis" force="true" />
-
-        <env name="LOGSTASH_REDIS_HOST" value="apisearch.redis" force="true" />
     </php>
 </phpunit>


### PR DESCRIPTION
- Basically, instead of calling a not-really important preload method
each time we use the console, we can dispatch some imperative events
(only accessible through static entrypoints like console commands)
- In this case, we use the method "LoadTokens"