### PR TITLE
Added origin control con queries

### DIFF
--- a/Controller/ControllerWithCommandBus.php
+++ b/Controller/ControllerWithCommandBus.php
@@ -41,13 +41,11 @@ abstract class ControllerWithCommandBus extends BaseController
     }
 
     /**
-     * Execute command.
-     *
      * @param object $command
      *
      * @return PromiseInterface
      */
-    public function execute($command)
+    protected function execute($command)
     {
         return $this
             ->commandBus

--- a/Controller/ControllerWithEventBus.php
+++ b/Controller/ControllerWithEventBus.php
@@ -42,15 +42,13 @@ abstract class ControllerWithEventBus extends BaseController
     }
 
     /**
-     * Dispatch event.
-     *
      * @param object $event
      *
      * @return PromiseInterface
      *
      * @throws InvalidEventException
      */
-    public function dispatch($event): PromiseInterface
+    protected function dispatch($event): PromiseInterface
     {
         return $this
             ->eventBus

--- a/Controller/ControllerWithQueryBus.php
+++ b/Controller/ControllerWithQueryBus.php
@@ -17,6 +17,7 @@ namespace Apisearch\Server\Controller;
 
 use Drift\CommandBus\Bus\QueryBus;
 use React\Promise\PromiseInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class ControllerWithQueryBus.
@@ -41,16 +42,38 @@ abstract class ControllerWithQueryBus extends BaseController
     }
 
     /**
-     * Ask query.
-     *
      * @param object $query
      *
      * @return PromiseInterface
      */
-    public function ask($query)
+    protected function ask($query)
     {
         return $this
             ->queryBus
             ->ask($query);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return string
+     */
+    protected function getOrigin(Request $request) : string
+    {
+        $headers = $request->headers;
+
+        return $headers->get('Origin', '');
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return string
+     */
+    protected function getRemoteAddr(Request $request) : string
+    {
+        $headers = $request->headers;
+
+        return $headers->get('HTTP_X_FORWARDED_FOR', $headers->get('REMOTE_ADDR', $headers->get('HTTP_CLIENT_IP', '')));
     }
 }

--- a/Controller/QueryCORSController.php
+++ b/Controller/QueryCORSController.php
@@ -36,9 +36,7 @@ class QueryCORSController extends ControllerWithQueryBus
      */
     public function __invoke(Request $request): PromiseInterface
     {
-        $headers = $request->headers;
-        $origin = $headers->get('Origin', '');
-
+        $origin = $this->getOrigin($request);
         $ip = $this->getRemoteAddr($request);
 
         return $this
@@ -81,17 +79,5 @@ class QueryCORSController extends ControllerWithQueryBus
     private function createForbiddenResponse()
     {
         return new Response(null, 403);
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return string
-     */
-    private function getRemoteAddr(Request $request) : string
-    {
-        $headers = $request->headers;
-
-        return $headers->get('HTTP_X_FORWARDED_FOR', $headers->get('REMOTE_ADDR', $headers->get('HTTP_CLIENT_IP', '')));
     }
 }

--- a/Controller/QueryController.php
+++ b/Controller/QueryController.php
@@ -42,6 +42,8 @@ class QueryController extends ControllerWithQueryBus
     {
         $requestQuery = $request->query;
         $queryModel = RequestAccessor::extractQuery($request);
+        $origin = $this->getOrigin($request);
+        $ip = $this->getRemoteAddr($request);
 
         return $this
             ->ask(new Query(
@@ -55,7 +57,9 @@ class QueryController extends ControllerWithQueryBus
                     return !\in_array($key, [
                         Http::TOKEN_FIELD,
                     ]);
-                }, ARRAY_FILTER_USE_KEY)
+                }, ARRAY_FILTER_USE_KEY),
+                $origin,
+                $ip
             ))
             ->then(function (Result $result) use ($requestQuery, $request) {
                 /*

--- a/Domain/Middleware/TokenQueryMiddleware.php
+++ b/Domain/Middleware/TokenQueryMiddleware.php
@@ -88,7 +88,10 @@ final class TokenQueryMiddleware implements DiscriminableMiddleware
         $query = new Query(
             $query->getRepositoryReference(),
             $token,
-            QueryModel::createFromArray($queryAsArray)
+            QueryModel::createFromArray($queryAsArray),
+            $query->getParameters(),
+            $query->getOrigin(),
+            $query->getIP()
         );
 
         return $next($query);

--- a/Domain/Query/Query.php
+++ b/Domain/Query/Query.php
@@ -42,16 +42,30 @@ class Query extends CommandWithRepositoryReferenceAndToken implements LoggableCo
     private $parameters = [];
 
     /**
+     * @var string
+     */
+    private $origin;
+
+    /**
+     * @var string
+     */
+    private $ip;
+
+    /**
      * @param RepositoryReference $repositoryReference
      * @param Token               $token
      * @param SearchQuery         $query
      * @param array               $parameters
+     * @param string              $origin
+     * @param string $ip
      */
     public function __construct(
         RepositoryReference $repositoryReference,
         Token $token,
         SearchQuery $query,
-        array $parameters = []
+        array $parameters = [],
+        string $origin = '',
+        string $ip = ''
     ) {
         parent::__construct(
             $repositoryReference,
@@ -60,6 +74,8 @@ class Query extends CommandWithRepositoryReferenceAndToken implements LoggableCo
 
         $this->query = $query;
         $this->parameters = $parameters;
+        $this->origin = $origin;
+        $this->ip = $ip;
     }
 
     /**
@@ -80,5 +96,21 @@ class Query extends CommandWithRepositoryReferenceAndToken implements LoggableCo
     public function getParameters(): array
     {
         return $this->parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrigin(): string
+    {
+        return $this->origin;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIP() : string
+    {
+        return $this->ip;
     }
 }

--- a/Plugin/Security/Domain/Middleware/RestrictedCORSOriginsMiddleware.php
+++ b/Plugin/Security/Domain/Middleware/RestrictedCORSOriginsMiddleware.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace Apisearch\Plugin\Security\Domain\Middleware;
+
+use Apisearch\Server\Domain\Plugin\PluginMiddleware;
+use Apisearch\Server\Domain\Query\GetCORSPermissions;
+use Closure;
+use React\Promise\PromiseInterface;
+use function React\Promise\resolve;
+
+/**
+ * Class RestrictedQueryOriginsMiddleware
+ */
+class RestrictedCORSOriginsMiddleware extends RestrictedOriginsMiddleware implements PluginMiddleware
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function onlyHandle(): array
+    {
+        return [
+            GetCORSPermissions::class,
+        ];
+    }
+
+    /**
+     * @param Object $command
+     * @param Closure $next
+     * @param bool $isAllowed
+     * @param string $origin
+     *
+     * @return PromiseInterface
+     */
+    protected function executeIfIsAllowed(
+        $command,
+        $next,
+        bool $isAllowed,
+        string $origin
+    ) : PromiseInterface
+    {
+        return resolve($isAllowed
+            ? $origin
+            : false);
+    }
+}

--- a/Plugin/Security/Domain/Middleware/RestrictedQueryOriginsMiddleware.php
+++ b/Plugin/Security/Domain/Middleware/RestrictedQueryOriginsMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Apisearch\Plugin\Security\Domain\Middleware;
+
+use Apisearch\Exception\ForbiddenException;
+use Apisearch\Server\Domain\Plugin\PluginMiddleware;
+use Apisearch\Server\Domain\Query\Query;
+use Closure;
+use React\Promise\PromiseInterface;
+use function React\Promise\reject;
+
+/**
+ * Class RestrictedQueryOriginsMiddleware
+ */
+class RestrictedQueryOriginsMiddleware extends RestrictedOriginsMiddleware implements PluginMiddleware
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function onlyHandle(): array
+    {
+        return [
+            Query::class,
+        ];
+    }
+
+    /**
+     * @param Object $command
+     * @param Closure $next
+     * @param bool $isAllowed
+     * @param string $origin
+     *
+     * @return PromiseInterface
+     */
+    protected function executeIfIsAllowed(
+        $command,
+        $next,
+        bool $isAllowed,
+        string $origin
+    ) : PromiseInterface
+    {
+        return $isAllowed
+            ? $next($command)
+            : reject(new ForbiddenException());
+    }
+}

--- a/Plugin/Security/Resources/config/domain.yml
+++ b/Plugin/Security/Resources/config/domain.yml
@@ -27,5 +27,8 @@ services:
     Apisearch\Plugin\Security\Domain\Middleware\RestrictedFieldsMiddleware:
         tags: ["apisearch_plugin.middleware"]
 
-    Apisearch\Plugin\Security\Domain\Middleware\RestrictedOriginsMiddleware:
+    Apisearch\Plugin\Security\Domain\Middleware\RestrictedCORSOriginsMiddleware:
+        tags: ["apisearch_plugin.middleware"]
+
+    Apisearch\Plugin\Security\Domain\Middleware\RestrictedQueryOriginsMiddleware:
         tags: ["apisearch_plugin.middleware"]

--- a/Plugin/Security/Tests/Functional/RestrictedCORSOriginsMiddlewareTest.php
+++ b/Plugin/Security/Tests/Functional/RestrictedCORSOriginsMiddlewareTest.php
@@ -22,7 +22,7 @@ use Apisearch\Server\Tests\Functional\CurlFunctionalTest;
 /**
  * Class CORSFunctionalTest.
  */
-class CORSFunctionalTest extends CurlFunctionalTest
+class RestrictedCORSOriginsMiddlewareTest extends CurlFunctionalTest
 {
     use SecurityFunctionalTestTrait;
 

--- a/Plugin/Security/Tests/Functional/RestrictedQueryOriginsMiddlewareTest.php
+++ b/Plugin/Security/Tests/Functional/RestrictedQueryOriginsMiddlewareTest.php
@@ -1,0 +1,79 @@
+<?php
+
+
+namespace Apisearch\Plugin\Security\Tests\Functional;
+
+use Apisearch\Config\Config;
+use Apisearch\Exception\ForbiddenException;
+use Apisearch\Query\Query;
+use Apisearch\Server\Tests\Functional\CurlFunctionalTest;
+
+/**
+ * Class QueryRestrictionsFunctionalTest
+ */
+class RestrictedQueryOriginsMiddlewareTest extends CurlFunctionalTest
+{
+    use SecurityFunctionalTestTrait;
+
+    /**
+     * Test mixed security
+     *
+     * @param array $allowedOrigins
+     * @param array $blockedIPs
+     * @param bool $allowed
+     *
+     * @dataProvider dataMixedSecurity
+     */
+    public function testMixedSecurity(
+        array $allowedOrigins,
+        array $blockedIPs,
+        bool $allowed
+    )
+    {
+        $this->configureIndex(Config::createEmpty()
+            ->addMetadataValue('allowed_domains', $allowedOrigins)
+            ->addMetadataValue('blocked_ips', $blockedIPs)
+        );
+
+        if (!$allowed) {
+            $this->expectException(ForbiddenException::class);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $this->query(
+            Query::createMatchAll(),
+            static::$appId,
+            '*',
+            null,
+            [],
+            [
+                'Origin: http://whatever.com',
+                'REMOTE_ADDR: 1.1.1.1'
+            ]
+        );
+    }
+
+    /**
+     * Data for mixed security.
+     *
+     * Accessing always with whatever.com and 1.1.1.1
+     *
+     * @return array
+     */
+    public function dataMixedSecurity() : array
+    {
+        return [
+            [['http://whatever.com'], ['1.1.1.2'], true],
+            [['whatever.com'], ['1.1.1.2'], true],
+            [['whatever.com'], [], true],
+            [[], [], true],
+            [[], ['1.1.1.2'], true],
+
+            [[], ['1.1.1.1'], false],
+            [['another.com'], ['1.1.1.1'], false],
+            [['another.com'], [], false],
+            [['another.com', 'yetanother.com'], ['1.1.1.1', '2.2.2.2'], false],
+        ];
+    }
+}


### PR DESCRIPTION
- Origin control was done only on CORS OPTIONS requests, but sometimes,
this mechanism is not used by the browser. Given that all the control
information is placed in memory, we can do the same control in the query
itself.