### PR TITLE
Added Fastly plugin + fixed delete-by-query

### DIFF
--- a/ApisearchPluginsBundle.php
+++ b/ApisearchPluginsBundle.php
@@ -18,6 +18,7 @@ namespace Apisearch\Server;
 use Apisearch\Plugin\Admin\AdminPluginBundle;
 use Apisearch\Plugin\DBAL\DBALPluginBundle;
 use Apisearch\Plugin\Elasticsearch\ElasticsearchPluginBundle;
+use Apisearch\Plugin\Fastly\FastlyPluginBundle;
 use Apisearch\Plugin\Logstash\LogstashPluginBundle;
 use Apisearch\Plugin\QueryMapper\QueryMapperPluginBundle;
 use Apisearch\Plugin\Security\SecurityPluginBundle;
@@ -82,6 +83,7 @@ class ApisearchPluginsBundle extends BaseBundle implements DependentBundleInterf
             'security' => SecurityPluginBundle::class,
             'query_mapper' => QueryMapperPluginBundle::class,
             'testing' => TestingPluginBundle::class,
+            'fastly' => FastlyPluginBundle::class,
         ];
 
         $combined = \array_combine(

--- a/Domain/Command/ConfigureIndex.php
+++ b/Domain/Command/ConfigureIndex.php
@@ -54,7 +54,7 @@ class ConfigureIndex extends CommandWithRepositoryReferenceAndToken implements W
      * @param Token               $token
      * @param IndexUUID           $indexUUID
      * @param Config              $config
-     * @param bool $forceReindex
+     * @param bool                $forceReindex
      */
     public function __construct(
         RepositoryReference $repositoryReference,
@@ -96,7 +96,7 @@ class ConfigureIndex extends CommandWithRepositoryReferenceAndToken implements W
     /**
      * @return bool
      */
-    public function forceReindex() : bool
+    public function forceReindex(): bool
     {
         return $this->forceReindex;
     }

--- a/Domain/Middleware/ComplexFields/ResetOrDeleteIndexComplexFieldsMiddleware.php
+++ b/Domain/Middleware/ComplexFields/ResetOrDeleteIndexComplexFieldsMiddleware.php
@@ -35,7 +35,7 @@ class ResetOrDeleteIndexComplexFieldsMiddleware extends ComplexFieldsMiddleware 
     public function execute($command, callable $next)
     {
         /**
-         * @var CommandWithRepositoryReferenceAndTokenAndIndexUUID $command
+         * @var CommandWithRepositoryReferenceAndTokenAndIndexUUID
          */
         $repositoryReference = $command->getRepositoryReference();
 
@@ -66,7 +66,7 @@ class ResetOrDeleteIndexComplexFieldsMiddleware extends ComplexFieldsMiddleware 
     {
         return [
             ResetIndex::class,
-            DeleteIndex::class
+            DeleteIndex::class,
         ];
     }
 }

--- a/Plugin/Fastly/FastlyPluginBundle.php
+++ b/Plugin/Fastly/FastlyPluginBundle.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\Fastly;
+
+use Apisearch\Server\ApisearchServerBundle;
+use Apisearch\Server\Domain\Plugin\Plugin;
+use Mmoreram\BaseBundle\SimpleBaseBundle;
+use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Class FastlyPluginBundle.
+ */
+class FastlyPluginBundle extends SimpleBaseBundle implements Plugin, DependentBundleInterface
+{
+    /**
+     * Return all bundle dependencies.
+     *
+     * Values can be a simple bundle namespace or its instance
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return array
+     */
+    public static function getBundleDependencies(KernelInterface $kernel): array
+    {
+        return [
+            ApisearchServerBundle::class,
+        ];
+    }
+
+    /**
+     * get config files.
+     *
+     * @return array
+     */
+    public function getConfigFiles(): array
+    {
+        return [
+            'domain',
+        ];
+    }
+
+    /**
+     * Get plugin name.
+     *
+     * @return string
+     */
+    public function getPluginName(): string
+    {
+        return 'fastly';
+    }
+}

--- a/Plugin/Fastly/Listener/QueryHeaders.php
+++ b/Plugin/Fastly/Listener/QueryHeaders.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\Fastly\Listener;
+
+use Apisearch\Http\Http;
+use function React\Promise\resolve;
+use React\Promise\PromiseInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+/**
+ * Class QueryHeaders.
+ */
+class QueryHeaders implements EventSubscriberInterface
+{
+    /**
+     * @param ResponseEvent $event
+     */
+    public function addSurrogateKeys(ResponseEvent $event): PromiseInterface
+    {
+        return resolve()
+            ->then(function () use ($event) {
+                $request = $event->getRequest();
+                $routeName = $request->get('_route');
+
+                if ('apisearch_v1_query' == $routeName) {
+                    $this->addSurrogateKeysToQuery($event, false);
+
+                    return;
+                }
+
+                if ('apisearch_v1_query_all_indices' == $routeName) {
+                    $this->addSurrogateKeysToQuery($event, true);
+
+                    return;
+                }
+            });
+    }
+
+    /**
+     * @param ResponseEvent $event
+     * @param bool          $allIndices
+     *
+     * @return void
+     */
+    private function addSurrogateKeysToQuery(
+        ResponseEvent $event,
+        bool $allIndices
+    ): void {
+        $request = $event->getRequest();
+        $requestQuery = $request->query;
+        $requestAttributes = $request->attributes;
+
+        $token = $requestQuery->get(Http::TOKEN_FIELD);
+        $appUUID = $requestAttributes->get('app_id');
+        $indexUUID = $requestAttributes->get('index_id');
+        if (empty($indexUUID) || '*' === $indexUUID) {
+            $allIndices = true;
+        }
+
+        $surrogateKeys = [
+            'token-'.$token->getTokenUUID()->composeUUID(),
+            'app-'.$appUUID,
+        ];
+
+        if ($allIndices) {
+            $surrogateKeys[] = "all-indices-$appUUID";
+        } else {
+            $surrogateKeys = \array_merge(
+                $surrogateKeys,
+                \array_map(function (string $index) {
+                    return 'index-'.$index;
+                }, \array_map('trim', \explode(',', $indexUUID)))
+            );
+        }
+
+        $response = $event->getResponse();
+        $response->headers->set('Surrogate-Key', \implode(' ', $surrogateKeys));
+    }
+
+    /**
+     * @return array|void
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            ResponseEvent::class => [
+                ['addSurrogateKeys', 0],
+            ],
+        ];
+    }
+}

--- a/Plugin/Fastly/Resources/config/domain.yml
+++ b/Plugin/Fastly/Resources/config/domain.yml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Apisearch\Plugin\Fastly\Listener\:
+        resource: '../../Listener/'

--- a/Plugin/Fastly/Tests/FastlyPluginFunctionalTest.php
+++ b/Plugin/Fastly/Tests/FastlyPluginFunctionalTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\Fastly\Tests;
+
+use Apisearch\Plugin\Fastly\FastlyPluginBundle;
+use Apisearch\Server\Tests\Functional\CurlFunctionalTest;
+
+/**
+ * Class FastlyPluginFunctionalTest.
+ */
+abstract class FastlyPluginFunctionalTest extends CurlFunctionalTest
+{
+    /**
+     * Decorate bundles.
+     *
+     * @param array $bundles
+     *
+     * @return array
+     */
+    protected static function decorateBundles(array $bundles): array
+    {
+        $bundles[] = FastlyPluginBundle::class;
+
+        return $bundles;
+    }
+}

--- a/Plugin/Fastly/Tests/SurrogateKeysTest.php
+++ b/Plugin/Fastly/Tests/SurrogateKeysTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Apisearch Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Plugin\Fastly\Tests;
+
+use Apisearch\Query\Query;
+
+/**
+ * Class SurrogateKeysTest.
+ */
+class SurrogateKeysTest extends FastlyPluginFunctionalTest
+{
+    /**
+     * Test surrogate keys on query.
+     */
+    public function testSurrogateKeysOnQuery()
+    {
+        $this->query(Query::createMatchAll());
+        $surrogateKey = static::$lastResponse['headers']['surrogate-key'];
+
+        $this->assertEquals(\sprintf('%s %s %s',
+            'token-'.self::$godToken,
+            'app-'.self::$appId,
+            'index-'.self::$index
+        ), $surrogateKey);
+
+        $this->query(Query::createMatchAll(), static::$appId, '');
+        $surrogateKey = static::$lastResponse['headers']['surrogate-key'];
+
+        $this->assertEquals(\sprintf('%s %s %s',
+            'token-'.self::$godToken,
+            'app-'.self::$appId,
+            'all-indices-'.self::$appId
+        ), $surrogateKey);
+
+        $this->query(Query::createMatchAll(), static::$appId, '*');
+        $surrogateKey = static::$lastResponse['headers']['surrogate-key'];
+
+        $this->assertEquals(\sprintf('%s %s %s',
+            'token-'.self::$godToken,
+            'app-'.self::$appId,
+            'all-indices-'.self::$appId
+        ), $surrogateKey);
+
+        $this->query(Query::createMatchAll(), static::$appId, static::$index.','.static::$anotherIndex);
+        $surrogateKey = static::$lastResponse['headers']['surrogate-key'];
+
+        $this->assertEquals(\sprintf('%s %s %s %s',
+            'token-'.self::$godToken,
+            'app-'.self::$appId,
+            'index-'.self::$index,
+            'index-'.self::$anotherIndex
+        ), $surrogateKey);
+
+        $this->query(Query::createMatchAll(), static::$appId, static::$index.','.static::$anotherIndex.','.static::$yetAnotherIndex);
+        $surrogateKey = static::$lastResponse['headers']['surrogate-key'];
+
+        $this->assertEquals(\sprintf('%s %s %s %s %s',
+            'token-'.self::$godToken,
+            'app-'.self::$appId,
+            'index-'.self::$index,
+            'index-'.self::$anotherIndex,
+            'index-'.self::$yetAnotherIndex
+        ), $surrogateKey);
+    }
+
+    /**
+     * Test other endpoints.
+     */
+    public function testOtherEndpoints()
+    {
+        $this->resetIndex();
+        $this->assertFalse(\array_key_exists('surrogate-key', static::$lastResponse['headers']));
+    }
+}

--- a/Tests/Functional/ApisearchServerBundleFunctionalTest.php
+++ b/Tests/Functional/ApisearchServerBundleFunctionalTest.php
@@ -585,7 +585,7 @@ abstract class ApisearchServerBundleFunctionalTest extends BaseDriftFunctionalTe
      * Configure index using the bus.
      *
      * @param Config $config
-     * @param bool $forceReindex
+     * @param bool   $forceReindex
      * @param string $appId
      * @param string $index
      * @param Token  $token
@@ -621,7 +621,7 @@ abstract class ApisearchServerBundleFunctionalTest extends BaseDriftFunctionalTe
             return \array_key_exists($fieldToCheck, $index->getFields());
         });
 
-        return count($indices) === 1
+        return 1 === \count($indices)
             ? \reset($indices)
             : null;
     }

--- a/Tests/Functional/CurlFunctionalTest.php
+++ b/Tests/Functional/CurlFunctionalTest.php
@@ -74,8 +74,12 @@ abstract class CurlFunctionalTest extends ApisearchServerBundleFunctionalTest
         array $parameters = [],
         array $headers = []
     ): Result {
+        $route = '' === $index
+            ? 'v1_query_all_indices'
+            : 'v1_query';
+
         $response = self::makeCurl(
-            'v1_query',
+            $route,
             [
                 'app_id' => $appId ?? static::$appId,
                 'index_id' => $index ?? static::$index,
@@ -369,7 +373,7 @@ abstract class CurlFunctionalTest extends ApisearchServerBundleFunctionalTest
      * Configure index using the bus.
      *
      * @param Config $config
-     * @param bool $forceReindex
+     * @param bool   $forceReindex
      * @param string $appId
      * @param string $index
      * @param Token  $token
@@ -390,7 +394,7 @@ abstract class CurlFunctionalTest extends ApisearchServerBundleFunctionalTest
             $token,
             $config->toArray(),
             [
-                'force_reindex' => $forceReindex
+                'force_reindex' => $forceReindex,
             ]
         );
     }

--- a/Tests/Functional/Domain/Repository/ComplexFieldsTest.php
+++ b/Tests/Functional/Domain/Repository/ComplexFieldsTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 namespace Apisearch\Server\Tests\Functional\Domain\Repository;
 
-use Apisearch\Model\Index;
 use Apisearch\Model\Item;
 use Apisearch\Model\ItemUUID;
 use Apisearch\Query\Filter;

--- a/Tests/Functional/Domain/Repository/IndexConfigurationTest.php
+++ b/Tests/Functional/Domain/Repository/IndexConfigurationTest.php
@@ -59,7 +59,7 @@ trait IndexConfigurationTest
 
     /**
      * Test soft configuration, for example, changing a simple metadata. That
-     * should not reindex
+     * should not reindex.
      */
     public function testSoftConfigureIndex()
     {
@@ -71,7 +71,7 @@ trait IndexConfigurationTest
     }
 
     /**
-     * Test force configuration reindex
+     * Test force configuration reindex.
      */
     public function testConfigurationIndexWithForceReindex()
     {

--- a/Tests/Functional/Domain/Repository/IndicesTest.php
+++ b/Tests/Functional/Domain/Repository/IndicesTest.php
@@ -15,8 +15,6 @@ declare(strict_types=1);
 
 namespace Apisearch\Server\Tests\Functional\Domain\Repository;
 
-use Apisearch\Model\Index;
-
 /**
  * Class IndicesTest.
  */

--- a/Tests/Functional/Domain/Repository/ItemsDeletionByQueryTest.php
+++ b/Tests/Functional/Domain/Repository/ItemsDeletionByQueryTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Apisearch\Server\Tests\Functional\Domain\Repository;
 
+use Apisearch\Query\Filter;
 use Apisearch\Query\Query;
 
 /**
@@ -51,6 +52,21 @@ trait ItemsDeletionByQueryTest
     {
         $this->deleteItemsByQuery(Query::create('', 1, 1)->filterByRange('cheap', 'price', [], ['0..1501']));
         $this->assertCount(1, $this->query(Query::createMatchAll())->getItems());
+
+        static::resetScenario();
+    }
+
+    /**
+     * Test item deletion with EXCLUDE filter.
+     *
+     * @group lala
+     */
+    public function testItemDeletionByExclude()
+    {
+        $this->deleteItemsByQuery(Query::create('', 1, 1)->filterBy('but_pink', 'color', ['pink'], Filter::EXCLUDE));
+        $this->assertCount(1, $this->query(Query::createMatchAll())->getItems());
+        $this->deleteItemsByQuery(Query::create('', 1, 1)->filterBy('another', 'non-existing', ['what'], Filter::EXCLUDE));
+        $this->assertCount(0, $this->query(Query::createMatchAll())->getItems());
 
         static::resetScenario();
     }

--- a/Tests/Functional/Domain/Repository/MetadataRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/MetadataRepositoryTest.php
@@ -17,7 +17,6 @@ namespace Apisearch\Server\Tests\Functional\Domain\Repository;
 
 use Apisearch\Config\Config;
 use Apisearch\Model\AppUUID;
-use Apisearch\Model\Index;
 use Apisearch\Model\IndexUUID;
 use Apisearch\Model\Item;
 use Apisearch\Model\Token;

--- a/Tests/Functional/Domain/Repository/RepositoryResetTest.php
+++ b/Tests/Functional/Domain/Repository/RepositoryResetTest.php
@@ -41,7 +41,7 @@ trait RepositoryResetTest
     }
 
     /**
-     * Test reset after field change
+     * Test reset after field change.
      */
     public function testResetRepositoryAfterFieldChange()
     {
@@ -49,20 +49,20 @@ trait RepositoryResetTest
             Item::createFromArray([
                 'uuid' => [
                     'id' => '10',
-                    'type' => 'test'
+                    'type' => 'test',
                 ],
                 'indexed_metadata' => [
                     'an_object' => [
                         'id' => '10',
-                        'name' => 'lol'
-                    ]
-                ]
-            ])
+                        'name' => 'lol',
+                    ],
+                ],
+            ]),
         ]);
 
         $index = $this->getPrincipalIndex();
         $this->assertEquals('object', $index->getFields()['indexed_metadata.an_object']);
-        $this->assertTrue(in_array('an_object', $index->getMetadataValue('stored_metadata')['complex_fields']));
+        $this->assertTrue(\in_array('an_object', $index->getMetadataValue('stored_metadata')['complex_fields']));
 
         $this->resetIndex();
         $this->assertCount(
@@ -77,19 +77,19 @@ trait RepositoryResetTest
             Item::createFromArray([
                 'uuid' => [
                     'id' => '10',
-                    'type' => 'test'
+                    'type' => 'test',
                 ],
                 'indexed_metadata' => [
                     'an_object' => [
                         'obj1',
-                        'obj2'
-                    ]
-                ]
-            ])
+                        'obj2',
+                    ],
+                ],
+            ]),
         ]);
 
         $index = $this->getPrincipalIndex('indexed_metadata.an_object');
-        $this->assertFalse(array_key_exists('complex_fields', $index->getMetadataValue('stored_metadata')));
+        $this->assertFalse(\array_key_exists('complex_fields', $index->getMetadataValue('stored_metadata')));
         $this->resetScenario();
     }
 }

--- a/Tests/Functional/HttpFunctionalTest.php
+++ b/Tests/Functional/HttpFunctionalTest.php
@@ -233,7 +233,7 @@ abstract class HttpFunctionalTest extends ApisearchServerBundleFunctionalTest
      * Configure index using the bus.
      *
      * @param Config $config
-     * @param bool $forceReindex
+     * @param bool   $forceReindex
      * @param string $appId
      * @param string $index
      * @param Token  $token

--- a/Tests/Functional/ServiceFunctionalTest.php
+++ b/Tests/Functional/ServiceFunctionalTest.php
@@ -371,7 +371,7 @@ abstract class ServiceFunctionalTest extends ApisearchServerBundleFunctionalTest
      * Configure index using the bus.
      *
      * @param Config $config
-     * @param bool $forceReindex
+     * @param bool   $forceReindex
      * @param string $appId
      * @param string $index
      * @param Token  $token


### PR DESCRIPTION
- Added fastly surrogate-keys on query calls
  Adding query for
    - token
    - app
    - each index. When all indices (all indices endpoint, '' or '*'),
special key is used

- Fixed delete-by-query. Refreshing before deleting as exposed here - https://discuss.elastic.co/t/elasticsearch-delete-by-query-409-version-conflict/174150