### PR TITLE
Fixed path to server

### DIFF
--- a/Tests/Functional/ApisearchServerBundleFunctionalTest.php
+++ b/Tests/Functional/ApisearchServerBundleFunctionalTest.php
@@ -350,8 +350,12 @@ abstract class ApisearchServerBundleFunctionalTest extends BaseDriftFunctionalTe
             static::$lastServer = null;
         }
 
+        $serverPath = is_dir(__DIR__.'/../../vendor/bin')
+            ? __DIR__.'/../../vendor/bin'
+            : __DIR__.'/../../../../bin';
+
         static::$lastServer = static::runServer(
-            __DIR__.'/../../vendor/bin',
+            $serverPath,
             static::HTTP_TEST_SERVICE_PORT, static::quietServer() ? [
                 '--quiet',
             ] : []


### PR DESCRIPTION
- old path when working on the server tests
- in-vendor path when working as a vendor dependency